### PR TITLE
Basic AWS support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ WORKDIR /go/src/github.com/ernestio/instance-adapter
 
 RUN make deps && go install
 
-ENTRYPOINT /go/bin/instance-adapter
+ENTRYPOINT ./entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+echo "Starting instance-adapter"
+/go/bin/instance-adapter

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ func getConnectorTypes(ctype string) []string {
 	return connectors[ctype]
 }
 
-func main() {
+func setup() {
 	nc = ecc.NewConfig(os.Getenv("NATS_URI")).Nats()
 
 	c := o.Config{
@@ -50,9 +50,13 @@ func main() {
 	}
 
 	log.Println("Setting up routers")
-	o.StandardSubscription(&c, "instance.create", "instance_type")
-	o.StandardSubscription(&c, "instance.update", "instance_type")
-	o.StandardSubscription(&c, "instance.delete", "instance_type")
+	t := Translator{}
+	o.TranslatedSubscription(&c, "instance.create", "_type", t)
+	o.TranslatedSubscription(&c, "instance.update", "_type", t)
+	o.TranslatedSubscription(&c, "instance.delete", "_type", t)
+}
 
+func main() {
+	setup()
 	runtime.Goexit()
 }

--- a/main_test.go
+++ b/main_test.go
@@ -38,10 +38,10 @@ func TestBasicRedirections(t *testing.T) {
 		chvcl := make(chan bool)
 
 		n.Subscribe("config.get.connectors", func(msg *nats.Msg) {
-			n.Publish(msg.Reply, []byte(`{"executions":["fake","salt"],"firewalls":["fake","vcloud"],"instances":["fake","vcloud"],"nats":["fake","vcloud"],"networks":["fake","vcloud"],"routers":["fake","vcloud"]}`))
+			n.Publish(msg.Reply, []byte(`{"instances":["fake","vcloud","vcloud-fake","aws","aws-fake"]}`))
 		})
 
-		go main()
+		setup()
 
 		n.Subscribe("instance.create.fake", func(msg *nats.Msg) {
 			chfak <- true
@@ -54,18 +54,18 @@ func TestBasicRedirections(t *testing.T) {
 		})
 		Convey("When it receives an invalid fake message", func() {
 			n.Publish("instance.create", []byte(`{"service":"aaa"}`))
-			Convey("Then it should redirect it to a fake connector", func() {
-				So(wait(cherr), ShouldNotBeNil)
+			Convey("Then it should redirect it to instance error creation", func() {
+				So(wait(cherr), ShouldBeNil)
 			})
 		})
 		Convey("When it receives a valid fake message", func() {
-			n.Publish("instance.create", []byte(`{"service":"aaa","instance_type":"fake"}`))
+			n.Publish("instance.create", []byte(`{"service":"aaa","datacenter_type":"fake"}`))
 			Convey("Then it should redirect it to a fake connector", func() {
 				So(wait(chfak), ShouldBeNil)
 			})
 		})
 		Convey("When it receives a valid vcloud message", func() {
-			n.Publish("instance.create", []byte(`{"service":"aaa","instance_type":"vcloud"}`))
+			n.Publish("instance.create", []byte(`{"service":"aaa","datacenter_type":"vcloud"}`))
 			Convey("Then it should redirect it to a fake connector", func() {
 				So(wait(chvcl), ShouldBeNil)
 			})

--- a/translator.go
+++ b/translator.go
@@ -26,6 +26,7 @@ type builderEvent struct {
 	Catalog               string   `json:"reference_catalog"`
 	Image                 string   `json:"reference_image"`
 	Disks                 []disk   `json:"disks"`
+	InstanceAWSID         string   `json:"instance_aws_id"`
 	RouterName            string   `json:"router_name"`
 	RouterType            string   `json:"router_type"`
 	RouterIP              string   `json:"router_ip"`
@@ -94,6 +95,7 @@ type awsEvent struct {
 	InstanceImage         string   `json:"instance_image"`
 	InstanceType          string   `json:"instance_type"`
 	InstanceIP            string   `json:"instance_ip"`
+	InstanceAWSID         string   `json:"instance_aws_id"`
 	InstanceKeyPair       string   `json:"instance_key_pair"`
 	Status                string   `json:"status"`
 	ErrorCode             string   `json:"error_code"`
@@ -167,12 +169,12 @@ func (t Translator) builderToAwsConnector(input builderEvent) []byte {
 	output.DatacenterVpcID = input.DatacenterName
 	output.NetworkAWSID = input.NetworkAWSID
 	output.SecurityGroupAWSIDs = input.SecurityGroupAWSIDs
-	// TODO: Documentation says something about Private IPS, but can't find any specs about it
 	output.InstanceName = input.Name
 	output.InstanceImage = input.Image
 	output.InstanceType = input.Type
 	output.InstanceIP = input.IP
 	output.InstanceKeyPair = input.KeyPair
+	output.InstanceAWSID = input.InstanceAWSID
 	output.Status = input.Status
 	output.ErrorCode = input.ErrorCode
 	output.ErrorMessage = input.ErrorMessage
@@ -247,13 +249,13 @@ func (t Translator) awsConnectorToBuilder(j []byte) []byte {
 	output.DatacenterAccessKey = input.DatacenterAccessKey
 	output.DatacenterName = input.DatacenterVpcID
 	output.SecurityGroupAWSIDs = input.SecurityGroupAWSIDs
-	// TODO: Documentation says something about Private IPS, but can't find any specs about it
 	output.Name = input.InstanceName
 	output.Image = input.InstanceImage
 	output.Type = input.InstanceType
 	output.IP = input.InstanceIP
 	output.Status = input.Status
 	output.ErrorCode = input.ErrorCode
+	output.InstanceAWSID = input.InstanceAWSID
 	output.ErrorMessage = input.ErrorMessage
 
 	body, _ := json.Marshal(output)

--- a/translator.go
+++ b/translator.go
@@ -15,31 +15,34 @@ type disk struct {
 }
 
 type builderEvent struct {
-	Uuid               string `json:"_uuid"`
-	BatchID            string `json:"_batch_id"`
-	Type               string `json:"type"`
-	Service            string `json:"service"`
-	Name               string `json:"name"`
-	CPU                int    `json:"cpus"`
-	RAM                int    `json:"ram"`
-	IP                 string `json:"ip"`
-	Catalog            string `json:"reference_catalog"`
-	Image              string `json:"reference_image"`
-	Disks              []disk `json:"disks"`
-	RouterName         string `json:"router_name"`
-	RouterType         string `json:"router_type"`
-	RouterIP           string `json:"router_ip"`
-	ClientName         string `json:"client_name"`
-	DatacenterName     string `json:"datacenter_name"`
-	DatacenterPassword string `json:"datacenter_password"`
-	DatacenterRegion   string `json:"datacenter_region"`
-	DatacenterType     string `json:"datacenter_type"`
-	DatacenterUsername string `json:"datacenter_username"`
-	NetworkName        string `json:"network_name"`
-	VCloudURL          string `json:"vcloud_url"`
-	Status             string `json:"status"`
-	ErrorCode          string `json:"error_code"`
-	ErrorMessage       string `json:"error_message"`
+	Uuid                  string   `json:"_uuid"`
+	BatchID               string   `json:"_batch_id"`
+	Type                  string   `json:"type"`
+	Service               string   `json:"service"`
+	Name                  string   `json:"name"`
+	CPU                   int      `json:"cpus"`
+	RAM                   int      `json:"ram"`
+	IP                    string   `json:"ip"`
+	Catalog               string   `json:"reference_catalog"`
+	Image                 string   `json:"reference_image"`
+	Disks                 []disk   `json:"disks"`
+	RouterName            string   `json:"router_name"`
+	RouterType            string   `json:"router_type"`
+	RouterIP              string   `json:"router_ip"`
+	ClientName            string   `json:"client_name"`
+	DatacenterName        string   `json:"datacenter_name"`
+	DatacenterPassword    string   `json:"datacenter_password"`
+	DatacenterRegion      string   `json:"datacenter_region"`
+	DatacenterType        string   `json:"datacenter_type"`
+	DatacenterUsername    string   `json:"datacenter_username"`
+	DatacenterAccessToken string   `json:"datacenter_token"`
+	DatacenterAccessKey   string   `json:"datacenter_secret"`
+	NetworkName           string   `json:"network_name"`
+	SecurityGroupAWSIDs   []string `json:"security_group_aws_ids"`
+	VCloudURL             string   `json:"vcloud_url"`
+	Status                string   `json:"status"`
+	ErrorCode             string   `json:"error_code"`
+	ErrorMessage          string   `json:"error_message"`
 }
 
 type instanceResource struct {
@@ -76,23 +79,21 @@ type vcloudEvent struct {
 }
 
 type awsEvent struct {
-	Uuid    string `json:"_uuid"`
-	BatchID string `json:"_batch_id"`
-	Type    string `json:"_type"`
-	// TODO: Map correct fields
-	/*
-		DatacenterRegion      string `json:"datacenter_region,omitempty"`
-		DatacenterAccessToken string `json:"datacenter_access_token,omitempty"`
-		DatacenterAccessKey   string `json:"datacenter_access_key,omitempty"`
-		DatacenterVpcID       string `json:"datacenter_vpc_id,omitempty"`
-		NetworkSubnet         string `json:"network_subnet"`
-		DatacenterName        string `json:"datacenter_name,omitempty"`
-		DatacenterUsername    string `json:"datacenter_username,omitempty"`
-		DatacenterPassword    string `json:"datacenter_password,omitempty"`
-	*/
-	Status       string `json:"status"`
-	ErrorCode    string `json:"error_code"`
-	ErrorMessage string `json:"error_message"`
+	Uuid                  string   `json:"_uuid"`
+	BatchID               string   `json:"_batch_id"`
+	Type                  string   `json:"_type"`
+	DatacenterRegion      string   `json:"datacenter_region,omitempty"`
+	DatacenterAccessToken string   `json:"datacenter_access_token"`
+	DatacenterAccessKey   string   `json:"datacenter_access_key"`
+	DatacenterVpcID       string   `json:"datacenter_vpc_id,omitempty"`
+	NetworkAWSID          string   `json:"network_aws_id"`
+	SecurityGroupAWSIDs   []string `json:"security_group_aws_ids"`
+	InstanceName          string   `json:"instance_name"`
+	InstanceImage         string   `json:"instance_image"`
+	InstanceType          string   `json:"instance_type"`
+	Status                string   `json:"status"`
+	ErrorCode             string   `json:"error_code"`
+	ErrorMessage          string   `json:"error_message"`
 }
 
 type Translator struct{}
@@ -103,9 +104,9 @@ func (t Translator) BuilderToConnector(j []byte) []byte {
 	json.Unmarshal(j, &input)
 
 	switch input.DatacenterType {
-	case "vcloud", "vcloud_fake", "fake":
+	case "vcloud", "fake-vcloud", "fake":
 		output = t.builderToVCloudConnector(input)
-	case "aws", "aws_fake":
+	case "aws", "fake-aws":
 		output = t.builderToAwsConnector(input)
 	}
 
@@ -142,6 +143,9 @@ func (t Translator) builderToVCloudConnector(input builderEvent) []byte {
 	output.DatacenterPassword = input.DatacenterPassword
 	output.DatacenterType = input.DatacenterType
 	output.VCloudURL = input.VCloudURL
+	output.Status = input.Status
+	output.ErrorCode = input.ErrorCode
+	output.ErrorMessage = input.ErrorMessage
 
 	body, _ := json.Marshal(output)
 
@@ -153,15 +157,20 @@ func (t Translator) builderToAwsConnector(input builderEvent) []byte {
 
 	output.Uuid = input.Uuid
 	output.BatchID = input.BatchID
-	/*
-		output.Service = input.Service
-		output.Type = input.RouterType
-		output.DatacenterRegion = input.DatacenterRegion
-		output.DatacenterAccessToken = input.DatacenterAccessToken
-		output.DatacenterAccessKey = input.DatacenterAccessKey
-		output.DatacenterVpcID = input.DatacenterName
-		output.NetworkSubnet = input.NetworkSubnet
-	*/
+	output.Type = input.DatacenterType
+	output.DatacenterRegion = input.DatacenterRegion
+	output.DatacenterAccessToken = input.DatacenterAccessToken
+	output.DatacenterAccessKey = input.DatacenterAccessKey
+	output.DatacenterVpcID = input.DatacenterName
+	output.NetworkAWSID = input.NetworkName
+	output.SecurityGroupAWSIDs = input.SecurityGroupAWSIDs
+	// TODO: Documentation says something about Private IPS, but can't find any specs about it
+	output.InstanceName = input.Name
+	output.InstanceImage = input.Image
+	output.InstanceType = input.Type
+	output.Status = input.Status
+	output.ErrorCode = input.ErrorCode
+	output.ErrorMessage = input.ErrorMessage
 
 	body, _ := json.Marshal(output)
 
@@ -175,10 +184,10 @@ func (t Translator) ConnectorToBuilder(j []byte) []byte {
 	dec := json.NewDecoder(bytes.NewReader(j))
 	dec.Decode(&input)
 
-	switch input["datacenter_type"] {
-	case "vcloud", "vcloud_fake", "fake":
+	switch input["_type"] {
+	case "vcloud", "fake-vcloud", "fake":
 		output = t.vcloudConnectorToBuilder(j)
-	case "aws", "aws_fake":
+	case "aws", "fake-aws":
 		output = t.awsConnectorToBuilder(j)
 	}
 
@@ -211,6 +220,9 @@ func (t Translator) vcloudConnectorToBuilder(j []byte) []byte {
 	output.DatacenterPassword = input.DatacenterPassword
 	output.DatacenterType = input.DatacenterType
 	output.VCloudURL = input.VCloudURL
+	output.Status = input.Status
+	output.ErrorCode = input.ErrorCode
+	output.ErrorMessage = input.ErrorMessage
 
 	body, _ := json.Marshal(output)
 
@@ -225,13 +237,20 @@ func (t Translator) awsConnectorToBuilder(j []byte) []byte {
 	output.Uuid = input.Uuid
 	output.BatchID = input.BatchID
 	output.Type = input.Type
-	/*
-		output.DatacenterRegion = input.DatacenterRegion
-		output.DatacenterAccessToken = input.DatacenterAccessToken
-		output.DatacenterAccessKey = input.DatacenterAccessKey
-		output.DatacenterName = input.DatacenterVpcID
-		output.NetworkSubnet = input.NetworkSubnet
-	*/
+	output.DatacenterRegion = input.DatacenterRegion
+	output.DatacenterAccessToken = input.DatacenterAccessToken
+	output.DatacenterAccessKey = input.DatacenterAccessKey
+	output.DatacenterName = input.DatacenterVpcID
+	output.NetworkName = input.NetworkAWSID
+	output.SecurityGroupAWSIDs = input.SecurityGroupAWSIDs
+	// TODO: Documentation says something about Private IPS, but can't find any specs about it
+	output.Name = input.InstanceName
+	output.Image = input.InstanceImage
+	output.Type = input.InstanceType
+	output.Status = input.Status
+	output.ErrorCode = input.ErrorCode
+	output.ErrorMessage = input.ErrorMessage
+
 	body, _ := json.Marshal(output)
 
 	return body

--- a/translator.go
+++ b/translator.go
@@ -97,9 +97,7 @@ type awsEvent struct {
 	InstanceIP            string   `json:"instance_ip"`
 	InstanceAWSID         string   `json:"instance_aws_id"`
 	InstanceKeyPair       string   `json:"instance_key_pair"`
-	Status                string   `json:"status"`
-	ErrorCode             string   `json:"error_code"`
-	ErrorMessage          string   `json:"error_message"`
+	ErrorMessage          string   `json:"error"`
 }
 
 type Translator struct{}
@@ -175,9 +173,6 @@ func (t Translator) builderToAwsConnector(input builderEvent) []byte {
 	output.InstanceIP = input.IP
 	output.InstanceKeyPair = input.KeyPair
 	output.InstanceAWSID = input.InstanceAWSID
-	output.Status = input.Status
-	output.ErrorCode = input.ErrorCode
-	output.ErrorMessage = input.ErrorMessage
 
 	body, _ := json.Marshal(output)
 
@@ -253,10 +248,13 @@ func (t Translator) awsConnectorToBuilder(j []byte) []byte {
 	output.Image = input.InstanceImage
 	output.Type = input.InstanceType
 	output.IP = input.InstanceIP
-	output.Status = input.Status
-	output.ErrorCode = input.ErrorCode
 	output.InstanceAWSID = input.InstanceAWSID
-	output.ErrorMessage = input.ErrorMessage
+
+	if input.ErrorMessage != "" {
+		output.Status = "errored"
+		output.ErrorCode = "0"
+		output.ErrorMessage = input.ErrorMessage
+	}
 
 	body, _ := json.Marshal(output)
 

--- a/translator.go
+++ b/translator.go
@@ -39,6 +39,7 @@ type builderEvent struct {
 	DatacenterAccessKey   string   `json:"datacenter_secret"`
 	NetworkName           string   `json:"network_name"`
 	NetworkAWSID          string   `json:"network_aws_id"`
+	KeyPair               string   `json:"key_pair"`
 	SecurityGroupAWSIDs   []string `json:"security_group_aws_ids"`
 	VCloudURL             string   `json:"vcloud_url"`
 	Status                string   `json:"status"`
@@ -92,6 +93,8 @@ type awsEvent struct {
 	InstanceName          string   `json:"instance_name"`
 	InstanceImage         string   `json:"instance_image"`
 	InstanceType          string   `json:"instance_type"`
+	InstanceIP            string   `json:"instance_ip"`
+	InstanceKeyPair       string   `json:"instance_key_pair"`
 	Status                string   `json:"status"`
 	ErrorCode             string   `json:"error_code"`
 	ErrorMessage          string   `json:"error_message"`
@@ -168,6 +171,8 @@ func (t Translator) builderToAwsConnector(input builderEvent) []byte {
 	output.InstanceName = input.Name
 	output.InstanceImage = input.Image
 	output.InstanceType = input.Type
+	output.InstanceIP = input.IP
+	output.InstanceKeyPair = input.KeyPair
 	output.Status = input.Status
 	output.ErrorCode = input.ErrorCode
 	output.ErrorMessage = input.ErrorMessage
@@ -246,6 +251,7 @@ func (t Translator) awsConnectorToBuilder(j []byte) []byte {
 	output.Name = input.InstanceName
 	output.Image = input.InstanceImage
 	output.Type = input.InstanceType
+	output.IP = input.InstanceIP
 	output.Status = input.Status
 	output.ErrorCode = input.ErrorCode
 	output.ErrorMessage = input.ErrorMessage

--- a/translator.go
+++ b/translator.go
@@ -1,0 +1,238 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+type disk struct {
+	ID   int `json:"id"`
+	Size int `json:"size"`
+}
+
+type builderEvent struct {
+	Uuid               string `json:"_uuid"`
+	BatchID            string `json:"_batch_id"`
+	Type               string `json:"type"`
+	Service            string `json:"service"`
+	Name               string `json:"name"`
+	CPU                int    `json:"cpus"`
+	RAM                int    `json:"ram"`
+	IP                 string `json:"ip"`
+	Catalog            string `json:"reference_catalog"`
+	Image              string `json:"reference_image"`
+	Disks              []disk `json:"disks"`
+	RouterName         string `json:"router_name"`
+	RouterType         string `json:"router_type"`
+	RouterIP           string `json:"router_ip"`
+	ClientName         string `json:"client_name"`
+	DatacenterName     string `json:"datacenter_name"`
+	DatacenterPassword string `json:"datacenter_password"`
+	DatacenterRegion   string `json:"datacenter_region"`
+	DatacenterType     string `json:"datacenter_type"`
+	DatacenterUsername string `json:"datacenter_username"`
+	NetworkName        string `json:"network_name"`
+	VCloudURL          string `json:"vcloud_url"`
+	Status             string `json:"status"`
+	ErrorCode          string `json:"error_code"`
+	ErrorMessage       string `json:"error_message"`
+}
+
+type instanceResource struct {
+	CPU     int    `json:"cpus"`
+	RAM     int    `json:"ram"`
+	IP      string `json:"ip"`
+	Catalog string `json:"reference_catalog"`
+	Image   string `json:"reference_image"`
+	Disks   []disk `json:"disks"`
+}
+
+type vcloudEvent struct {
+	Uuid               string           `json:"_uuid"`
+	BatchID            string           `json:"_batch_id"`
+	Type               string           `json:"_type"`
+	Service            string           `json:"service_id"`
+	InstanceName       string           `json:"instance_name"`
+	InstanceType       string           `json:"instance_type"`
+	Resource           instanceResource `json:"instance_resource"`
+	RouterName         string           `json:"router_name"`
+	RouterType         string           `json:"router_type"`
+	RouterIP           string           `json:"router_ip"`
+	ClientName         string           `json:"client_name"`
+	DatacenterName     string           `json:"datacenter_name"`
+	DatacenterPassword string           `json:"datacenter_password"`
+	DatacenterRegion   string           `json:"datacenter_region"`
+	DatacenterType     string           `json:"datacenter_type"`
+	DatacenterUsername string           `json:"datacenter_username"`
+	NetworkName        string           `json:"network_name"`
+	VCloudURL          string           `json:"vcloud_url"`
+	Status             string           `json:"status"`
+	ErrorCode          string           `json:"error_code"`
+	ErrorMessage       string           `json:"error_message"`
+}
+
+type awsEvent struct {
+	Uuid    string `json:"_uuid"`
+	BatchID string `json:"_batch_id"`
+	Type    string `json:"_type"`
+	// TODO: Map correct fields
+	/*
+		DatacenterRegion      string `json:"datacenter_region,omitempty"`
+		DatacenterAccessToken string `json:"datacenter_access_token,omitempty"`
+		DatacenterAccessKey   string `json:"datacenter_access_key,omitempty"`
+		DatacenterVpcID       string `json:"datacenter_vpc_id,omitempty"`
+		NetworkSubnet         string `json:"network_subnet"`
+		DatacenterName        string `json:"datacenter_name,omitempty"`
+		DatacenterUsername    string `json:"datacenter_username,omitempty"`
+		DatacenterPassword    string `json:"datacenter_password,omitempty"`
+	*/
+	Status       string `json:"status"`
+	ErrorCode    string `json:"error_code"`
+	ErrorMessage string `json:"error_message"`
+}
+
+type Translator struct{}
+
+func (t Translator) BuilderToConnector(j []byte) []byte {
+	var input builderEvent
+	var output []byte
+	json.Unmarshal(j, &input)
+
+	switch input.DatacenterType {
+	case "vcloud", "vcloud_fake", "fake":
+		output = t.builderToVCloudConnector(input)
+	case "aws", "aws_fake":
+		output = t.builderToAwsConnector(input)
+	}
+
+	return output
+}
+
+func (t Translator) builderToVCloudConnector(input builderEvent) []byte {
+	var output vcloudEvent
+
+	resource := instanceResource{
+		CPU:     input.CPU,
+		RAM:     input.RAM,
+		IP:      input.IP,
+		Catalog: input.Catalog,
+		Image:   input.Image,
+		Disks:   input.Disks,
+	}
+
+	output.Uuid = input.Uuid
+	output.BatchID = input.BatchID
+	output.Type = input.DatacenterType
+	output.Service = input.Service
+	output.InstanceName = input.Name
+	output.InstanceType = input.DatacenterType
+	output.Resource = resource
+	output.RouterIP = input.RouterIP
+	output.RouterName = input.RouterName
+	output.RouterType = input.RouterType
+	output.NetworkName = input.NetworkName
+	output.ClientName = input.ClientName
+	output.DatacenterName = input.DatacenterName
+	output.DatacenterRegion = input.DatacenterRegion
+	output.DatacenterUsername = input.DatacenterUsername
+	output.DatacenterPassword = input.DatacenterPassword
+	output.DatacenterType = input.DatacenterType
+	output.VCloudURL = input.VCloudURL
+
+	body, _ := json.Marshal(output)
+
+	return body
+}
+
+func (t Translator) builderToAwsConnector(input builderEvent) []byte {
+	var output awsEvent
+
+	output.Uuid = input.Uuid
+	output.BatchID = input.BatchID
+	/*
+		output.Service = input.Service
+		output.Type = input.RouterType
+		output.DatacenterRegion = input.DatacenterRegion
+		output.DatacenterAccessToken = input.DatacenterAccessToken
+		output.DatacenterAccessKey = input.DatacenterAccessKey
+		output.DatacenterVpcID = input.DatacenterName
+		output.NetworkSubnet = input.NetworkSubnet
+	*/
+
+	body, _ := json.Marshal(output)
+
+	return body
+}
+
+func (t Translator) ConnectorToBuilder(j []byte) []byte {
+	var output []byte
+	var input map[string]interface{}
+
+	dec := json.NewDecoder(bytes.NewReader(j))
+	dec.Decode(&input)
+
+	switch input["datacenter_type"] {
+	case "vcloud", "vcloud_fake", "fake":
+		output = t.vcloudConnectorToBuilder(j)
+	case "aws", "aws_fake":
+		output = t.awsConnectorToBuilder(j)
+	}
+
+	return output
+}
+
+func (t Translator) vcloudConnectorToBuilder(j []byte) []byte {
+	var input vcloudEvent
+	var output builderEvent
+	json.Unmarshal(j, &input)
+
+	output.Uuid = input.Uuid
+	output.BatchID = input.BatchID
+	output.Type = input.RouterType
+	output.Service = input.Service
+	output.Name = input.InstanceName
+	output.CPU = input.Resource.CPU
+	output.RAM = input.Resource.RAM
+	output.IP = input.Resource.IP
+	output.Catalog = input.Resource.Catalog
+	output.Image = input.Resource.Image
+	output.Disks = input.Resource.Disks
+	output.RouterIP = input.RouterIP
+	output.RouterName = input.RouterName
+	output.RouterType = input.RouterType
+	output.ClientName = input.ClientName
+	output.NetworkName = input.NetworkName
+	output.DatacenterName = input.DatacenterName
+	output.DatacenterUsername = input.DatacenterUsername
+	output.DatacenterPassword = input.DatacenterPassword
+	output.DatacenterType = input.DatacenterType
+	output.VCloudURL = input.VCloudURL
+
+	body, _ := json.Marshal(output)
+
+	return body
+}
+
+func (t Translator) awsConnectorToBuilder(j []byte) []byte {
+	var input awsEvent
+	var output builderEvent
+	json.Unmarshal(j, &input)
+
+	output.Uuid = input.Uuid
+	output.BatchID = input.BatchID
+	output.Type = input.Type
+	/*
+		output.DatacenterRegion = input.DatacenterRegion
+		output.DatacenterAccessToken = input.DatacenterAccessToken
+		output.DatacenterAccessKey = input.DatacenterAccessKey
+		output.DatacenterName = input.DatacenterVpcID
+		output.NetworkSubnet = input.NetworkSubnet
+	*/
+	body, _ := json.Marshal(output)
+
+	return body
+}

--- a/translator.go
+++ b/translator.go
@@ -38,6 +38,7 @@ type builderEvent struct {
 	DatacenterAccessToken string   `json:"datacenter_token"`
 	DatacenterAccessKey   string   `json:"datacenter_secret"`
 	NetworkName           string   `json:"network_name"`
+	NetworkAWSID          string   `json:"network_aws_id"`
 	SecurityGroupAWSIDs   []string `json:"security_group_aws_ids"`
 	VCloudURL             string   `json:"vcloud_url"`
 	Status                string   `json:"status"`
@@ -104,9 +105,9 @@ func (t Translator) BuilderToConnector(j []byte) []byte {
 	json.Unmarshal(j, &input)
 
 	switch input.DatacenterType {
-	case "vcloud", "fake-vcloud", "fake":
+	case "vcloud", "vcloud-fake", "fake":
 		output = t.builderToVCloudConnector(input)
-	case "aws", "fake-aws":
+	case "aws", "aws-fake":
 		output = t.builderToAwsConnector(input)
 	}
 
@@ -146,7 +147,6 @@ func (t Translator) builderToVCloudConnector(input builderEvent) []byte {
 	output.Status = input.Status
 	output.ErrorCode = input.ErrorCode
 	output.ErrorMessage = input.ErrorMessage
-
 	body, _ := json.Marshal(output)
 
 	return body
@@ -162,7 +162,7 @@ func (t Translator) builderToAwsConnector(input builderEvent) []byte {
 	output.DatacenterAccessToken = input.DatacenterAccessToken
 	output.DatacenterAccessKey = input.DatacenterAccessKey
 	output.DatacenterVpcID = input.DatacenterName
-	output.NetworkAWSID = input.NetworkName
+	output.NetworkAWSID = input.NetworkAWSID
 	output.SecurityGroupAWSIDs = input.SecurityGroupAWSIDs
 	// TODO: Documentation says something about Private IPS, but can't find any specs about it
 	output.InstanceName = input.Name
@@ -185,9 +185,9 @@ func (t Translator) ConnectorToBuilder(j []byte) []byte {
 	dec.Decode(&input)
 
 	switch input["_type"] {
-	case "vcloud", "fake-vcloud", "fake":
+	case "vcloud", "vcloud-fake", "fake":
 		output = t.vcloudConnectorToBuilder(j)
-	case "aws", "fake-aws":
+	case "aws", "aws-fake":
 		output = t.awsConnectorToBuilder(j)
 	}
 
@@ -201,7 +201,7 @@ func (t Translator) vcloudConnectorToBuilder(j []byte) []byte {
 
 	output.Uuid = input.Uuid
 	output.BatchID = input.BatchID
-	output.Type = input.RouterType
+	output.Type = input.DatacenterType
 	output.Service = input.Service
 	output.Name = input.InstanceName
 	output.CPU = input.Resource.CPU
@@ -241,7 +241,6 @@ func (t Translator) awsConnectorToBuilder(j []byte) []byte {
 	output.DatacenterAccessToken = input.DatacenterAccessToken
 	output.DatacenterAccessKey = input.DatacenterAccessKey
 	output.DatacenterName = input.DatacenterVpcID
-	output.NetworkName = input.NetworkAWSID
 	output.SecurityGroupAWSIDs = input.SecurityGroupAWSIDs
 	// TODO: Documentation says something about Private IPS, but can't find any specs about it
 	output.Name = input.InstanceName


### PR DESCRIPTION
Adapters were conceived as the place to prepare an internal service to be consumed by a connector, so connectors can focus only on calling third party apis.

However they are quite dummy at the moment, they only get a message and redirect it to the consumer related to the provider.

The behaviour implemented here is:
- Have defined a connector mapping for each connector they support.
- Receive a message "component.process" with the related component partial of the service as this one.
- Call connector with a "component.process.provider"
- Receive a "component.process.provider.done" and map the result back to the partial of the service.
- And finally publish "component.process.done" with mapped partial.
